### PR TITLE
Fix bug where an undefined arrival airport will cause plugin to crash

### DIFF
--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -752,7 +752,7 @@ string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 			lineStr = lineStr.substr(0, lineStr.find("_"));  //always get route from spad/flight strip in case of version mismatch
 		}
 	}
-	else if (strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
+	else if (arptSet.find(FlightPlan.GetFlightPlanData().GetDestination()) != arptSet.end() && strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
 		string app = GetAvailableApps(FlightPlan.GetFlightPlanData().GetDestination(), FlightPlan.GetFlightPlanData().GetArrivalRwy())[0]; //selects default app if no assignment, which is [0]
 		if (app.find("_") != string::npos) {
 			lineStr = app.substr(0, app.find("_"));
@@ -762,7 +762,7 @@ string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 	}
 
 	if (lineStr.length() < 1) {
-		if (strlen(FlightPlan.GetFlightPlanData().GetSidName()) != 0) {
+		if (arptSet.find(FlightPlan.GetFlightPlanData().GetOrigin()) != arptSet.end && strlen(FlightPlan.GetFlightPlanData().GetSidName()) != 0) {
 			lineStr = FlightPlan.GetFlightPlanData().GetSidName();
 		}
 		else {
@@ -787,7 +787,7 @@ string AT3Tags::GetAMCLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 			lineStr = lineStr.substr(0, lineStr.find("_"));
 		}
 	}
-	else if (strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
+	else if (arptSet.find(FlightPlan.GetFlightPlanData().GetDestination()) != arptSet.end() && strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
 		string app = GetAvailableApps(FlightPlan.GetFlightPlanData().GetDestination(), FlightPlan.GetFlightPlanData().GetArrivalRwy())[0]; //selects default app if no assignment, which is [0]
 		if (app.find("_") != string::npos) {
 			lineStr = app.substr(0, app.find("_"));

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -762,7 +762,7 @@ string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 	}
 
 	if (lineStr.length() < 1) {
-		if (arptSet.find(FlightPlan.GetFlightPlanData().GetOrigin()) != arptSet.end && strlen(FlightPlan.GetFlightPlanData().GetSidName()) != 0) {
+		if (arptSet.find(FlightPlan.GetFlightPlanData().GetOrigin()) != arptSet.end() && strlen(FlightPlan.GetFlightPlanData().GetSidName()) != 0) {
 			lineStr = FlightPlan.GetFlightPlanData().GetSidName();
 		}
 		else {

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -908,9 +908,13 @@ string AT3Tags::GetVSIndicator(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 
 string AT3Tags::GetFormattedArrivalRwy(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 {
-	string runway = FlightPlan.GetFlightPlanData().GetArrivalRwy();
-	if (runway.length() < 3) {
-		runway.insert(runway.length(), 3 - runway.length(), ' ');
+	if (arptSet.find(FlightPlan.GetFlightPlanData().GetDestination()) != arptSet.end()) {
+		string runway = FlightPlan.GetFlightPlanData().GetArrivalRwy();
+		if (runway.length() < 3) {
+			runway.insert(runway.length(), 3 - runway.length(), ' ');
+		}
+		return runway;
+	} else {
+		return "   ";
 	}
-	return runway;
 }

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -703,7 +703,7 @@ string AT3Tags::GetRouteCodeLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTa
 				lineStr = lineStr.substr(0, lineStr.find("_"));
 			}
 		}
-		else if (strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
+		else if (arptSet.find(FlightPlan.GetFlightPlanData().GetDestination()) != arptSet.end() && strlen(FlightPlan.GetFlightPlanData().GetArrivalRwy()) != 0) {
 			for (auto& rte : rteJson[FlightPlan.GetFlightPlanData().GetDestination()][runway.substr(0, 2)]["routes"].items()) { //matches exact route only for auto assigning route code
 				if (fpRoute.find(rte.value()["route"]) != string::npos) {
 					lineStr = rte.key();


### PR DESCRIPTION
~(I am 99% sure this is why, but I don't currently  have access to a computer with VS installed and the WiFi at my hotel is not exactly fast so I haven't been able to test it yet. Will try to install VS on my laptop tonight but if I'm not able to can someone pretty please test it for me uwu 👉👈)~
ppdate: installed VS, tested, it works and i am stupid

## Testing instructions
- start a sweatbox session
- use a tag with the APPDEPLine4 or AMCLine4 element
- assume and expand its tag 
- create a fpl for an aircraft from departing VHHH and not landing at VHHH, VHHX or VMMC
- assign it a SID
- append [STAR]/[RUNWAY] to the flight plan
- switch between the tagged(expanded) and untagged states
- click the line 4 element; it should not open the approach selection menu

expected result:
- line 4 should display the SID once it has been assigned, regardless of whether a STAR was added to the flight plan
- the approach selection menu does not open when line 4 is clicked
