### PR TITLE
fix(AT3): Make due north track display as 360 instead of 000

### DIFF
--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -586,6 +586,11 @@ string AT3Tags::GetFormattedAltitudedAssigned(CFlightPlan& FlightPlan, CRadarTar
 string AT3Tags::GetFormattedTrack(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 {
 	string track = to_string(static_cast<int>(trunc(RadarTarget.GetTrackHeading())));
+
+	if (track == "0") {
+		track = "360";
+	}
+
 	if (track.length() <= 3) {
 		track.insert(0, 3 - track.length(), '0');
 	}


### PR DESCRIPTION
## Changelog
- A due north track now displays "360" instead of "000".

Resolves #40